### PR TITLE
Simplify authorized loader.

### DIFF
--- a/test/output-app/README.md
+++ b/test/output-app/README.md
@@ -98,16 +98,12 @@ import { queryForRoles, findByIds } from '../server/authorize';
 export default class <Type> {
   constructor(context){
 	...
-	this.loaders = (_user = {}, resolver = '') => ({
-	  readOne: new DataLoader(ids => new Promise( async (resolve, reject) => {
-	    try {
-	      const authQuery = queryForRoles(_user, ['admin', 'world'], ['authorId', 'coauthorsIds'], 'readOne', { User: this.context.User }, resolver);
-	      const result = await findByIds(this.collection, ids, authQuery);
-	      resolve(result);
-	    } catch (err) { reject(err); }
-	  })),
-	});
-	...
+	
+	this.unauthorizedLoader = new DataLoader(ids => findByIds(this.collection, ids));
+	
+	const { user: me, User } = context;
+	const authQuery = queryForRoles(me, ['admin', 'world'], ['authorId', 'coauthorsIds'], 'readOne', { User }, 'findOneLoader');
+	this.authorizedLoader = new DataLoader(ids => findByIds(this.collection, ids, authQuery));
   }
 ...
 async getOneById(id, _user = {}, resolver = 'tweet getOneById') {


### PR DESCRIPTION
Thoughts here:

1. We only need one authorized loader (for the `readOne` case).
2. We can determine the `authQuery` at initialization time, assuming that a single user will be used for all queries (this is the case).
3. We can have the user at initialization time, although this will require refactoring the way the context is initialized here: https://github.com/tobkle/create-graphql-server/blob/master/skel/server/index.js

  i. We need to add the models to the context *after* the authentication, i.e. here: https://github.com/tobkle/create-graphql-server/blob/master/skel/server/index.js#L44

 ii. This will mean that we need a different reference to the mongo collection in the `passport.authenticate` call. But we can make that work I think, it doesn't really need the proper user collection.

4. I don't think your promise constructor is required, promises already do that by default if I am reading it right.